### PR TITLE
feat: Implement DataSource interface and mock for #37

### DIFF
--- a/internal/datasource/datasource.go
+++ b/internal/datasource/datasource.go
@@ -5,6 +5,8 @@ import (
 	"time"
 )
 
+// DataSource defines the common interface for all data sources in PubDataHub.
+// This interface ensures consistency across different data source implementations.
 type DataSource interface {
 	// Metadata
 	Name() string
@@ -25,6 +27,7 @@ type DataSource interface {
 	GetStoragePath() string
 }
 
+// DownloadStatus represents the current status of a data download operation.
 type DownloadStatus struct {
 	IsActive     bool
 	Progress     float64 // 0.0 to 1.0
@@ -35,6 +38,7 @@ type DownloadStatus struct {
 	ErrorMessage string
 }
 
+// QueryResult holds the results of a data query.
 type QueryResult struct {
 	Columns  []string
 	Rows     [][]interface{}
@@ -42,6 +46,24 @@ type QueryResult struct {
 	Duration time.Duration
 }
 
+// Schema represents the schema of the data provided by a data source.
+// This is a placeholder and can be expanded with more detailed schema information (e.g., column types, constraints).
 type Schema struct {
-	// Define schema structure as needed
+	// TODO: Define detailed schema structure
+	Tables []TableSchema
 }
+
+// TableSchema represents the schema for a single table within a data source.
+type TableSchema struct {
+	Name    string
+	Columns []ColumnSchema
+}
+
+// ColumnSchema represents the schema for a single column within a table.
+type ColumnSchema struct {
+	Name string
+	Type string // e.g., "TEXT", "INTEGER", "REAL", "BLOB"
+}
+
+// TODO: Create data source registry for managing multiple sources
+// TODO: Create mock implementation for testing

--- a/internal/datasource/datasource_test.go
+++ b/internal/datasource/datasource_test.go
@@ -1,0 +1,65 @@
+package datasource_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/brainless/PubDataHub/internal/datasource"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDataSourceInterface(t *testing.T) {
+	// Ensure MockDataSource implements DataSource interface
+	var _ datasource.DataSource = &datasource.MockDataSource{}
+
+	mockDS := datasource.NewMockDataSource("TestSource", "A data source for testing")
+
+	assert.Equal(t, "TestSource", mockDS.Name())
+	assert.Equal(t, "A data source for testing", mockDS.Description())
+
+	// Test DownloadStatus
+	dlStatus := mockDS.GetDownloadStatus()
+	assert.False(t, dlStatus.IsActive)
+	assert.Equal(t, "idle", dlStatus.Status)
+
+	// Test StartDownload
+	err := mockDS.StartDownload(context.Background())
+	assert.NoError(t, err)
+	dlStatus = mockDS.GetDownloadStatus()
+	assert.True(t, dlStatus.IsActive)
+	assert.Equal(t, "downloading", dlStatus.Status)
+	assert.InDelta(t, 0.5, dlStatus.Progress, 0.001)
+
+	// Test PauseDownload
+	err = mockDS.PauseDownload()
+	assert.NoError(t, err)
+	dlStatus = mockDS.GetDownloadStatus()
+	assert.False(t, dlStatus.IsActive)
+	assert.Equal(t, "paused", dlStatus.Status)
+
+	// Test ResumeDownload
+	err = mockDS.ResumeDownload(context.Background())
+	assert.NoError(t, err)
+	dlStatus = mockDS.GetDownloadStatus()
+	assert.True(t, dlStatus.IsActive)
+	assert.Equal(t, "downloading", dlStatus.Status)
+
+	// Test Query
+	qr, err := mockDS.Query("SELECT * FROM mock_table")
+	assert.NoError(t, err)
+	assert.Equal(t, 2, qr.Count)
+	assert.Len(t, qr.Columns, 2)
+	assert.Len(t, qr.Rows, 2)
+
+	// Test Schema
+	schema := mockDS.GetSchema()
+	assert.Len(t, schema.Tables, 1)
+	assert.Equal(t, "mock_table", schema.Tables[0].Name)
+	assert.Len(t, schema.Tables[0].Columns, 2)
+
+	// Test InitializeStorage and GetStoragePath
+	storagePath := "/tmp/test_storage"
+	err = mockDS.InitializeStorage(storagePath)
+	assert.NoError(t, err)
+	assert.Equal(t, storagePath, mockDS.GetStoragePath())
+}

--- a/internal/datasource/mock_datasource.go
+++ b/internal/datasource/mock_datasource.go
@@ -1,0 +1,114 @@
+package datasource
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// MockDataSource is a mock implementation of the DataSource interface for testing purposes.
+type MockDataSource struct {
+	name           string
+	description    string
+	downloadStatus DownloadStatus
+	queryResult    QueryResult
+	schema         Schema
+	storagePath    string
+}
+
+// NewMockDataSource creates a new instance of MockDataSource.
+func NewMockDataSource(name, description string) *MockDataSource {
+	return &MockDataSource{
+		name:        name,
+		description: description,
+		downloadStatus: DownloadStatus{
+			IsActive:   false,
+			Progress:   0.0,
+			Status:     "idle",
+			LastUpdate: time.Now(),
+		},
+		queryResult: QueryResult{
+			Columns:  []string{"id", "name"},
+			Rows:     [][]interface{}{{1, "test1"}, {2, "test2"}},
+			Count:    2,
+			Duration: 10 * time.Millisecond,
+		},
+		schema: Schema{
+			Tables: []TableSchema{
+				{
+					Name: "mock_table",
+					Columns: []ColumnSchema{
+						{Name: "id", Type: "INTEGER"},
+						{Name: "name", Type: "TEXT"},
+					},
+				},
+			},
+		},
+	}
+}
+
+// Name returns the name of the mock data source.
+func (m *MockDataSource) Name() string {
+	return m.name
+}
+
+// Description returns the description of the mock data source.
+func (m *MockDataSource) Description() string {
+	return m.description
+}
+
+// GetDownloadStatus returns the current download status of the mock data source.
+func (m *MockDataSource) GetDownloadStatus() DownloadStatus {
+	return m.downloadStatus
+}
+
+// StartDownload simulates starting a download for the mock data source.
+func (m *MockDataSource) StartDownload(ctx context.Context) error {
+	m.downloadStatus.IsActive = true
+	m.downloadStatus.Status = "downloading"
+	m.downloadStatus.Progress = 0.5
+	m.downloadStatus.LastUpdate = time.Now()
+	fmt.Printf("MockDataSource %s: Download started\n", m.name)
+	return nil
+}
+
+// PauseDownload simulates pausing a download for the mock data source.
+func (m *MockDataSource) PauseDownload() error {
+	m.downloadStatus.IsActive = false
+	m.downloadStatus.Status = "paused"
+	m.downloadStatus.LastUpdate = time.Now()
+	fmt.Printf("MockDataSource %s: Download paused\n", m.name)
+	return nil
+}
+
+// ResumeDownload simulates resuming a download for the mock data source.
+func (m *MockDataSource) ResumeDownload(ctx context.Context) error {
+	m.downloadStatus.IsActive = true
+	m.downloadStatus.Status = "downloading"
+	m.downloadStatus.LastUpdate = time.Now()
+	fmt.Printf("MockDataSource %s: Download resumed\n", m.name)
+	return nil
+}
+
+// Query simulates executing a query against the mock data source.
+func (m *MockDataSource) Query(query string) (QueryResult, error) {
+	fmt.Printf("MockDataSource %s: Executing query: %s\n", m.name, query)
+	return m.queryResult, nil
+}
+
+// GetSchema returns the schema of the mock data source.
+func (m *MockDataSource) GetSchema() Schema {
+	return m.schema
+}
+
+// InitializeStorage simulates initializing storage for the mock data source.
+func (m *MockDataSource) InitializeStorage(storagePath string) error {
+	m.storagePath = storagePath
+	fmt.Printf("MockDataSource %s: Storage initialized at %s\n", m.name, storagePath)
+	return nil
+}
+
+// GetStoragePath returns the storage path of the mock data source.
+func (m *MockDataSource) GetStoragePath() string {
+	return m.storagePath
+}


### PR DESCRIPTION
This PR implements the DataSource interface and supporting types as defined in GitHub issue #37. It also includes a mock implementation and tests.

Closes #37