### PR TITLE
feat(api): Setup Web Server and API Boilerplate

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1,0 +1,67 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/brainless/PubDataHub/internal/log"
+)
+
+// Server represents the API server
+type Server struct {
+	httpServer *http.Server
+}
+
+// NewServer creates a new API server instance
+func NewServer(addr string) *Server {
+	mux := http.NewServeMux()
+
+	// Add a basic health check endpoint
+	mux.HandleFunc("/health", healthHandler)
+
+	// Add a basic root endpoint
+	mux.HandleFunc("/", rootHandler)
+
+	httpServer := &http.Server{
+		Addr:    addr,
+		Handler: mux,
+	}
+
+	return &Server{
+		httpServer: httpServer,
+	}
+}
+
+// Start starts the API server
+func (s *Server) Start() error {
+	log.Logger.Infof("Starting API server on %s", s.httpServer.Addr)
+
+	if err := s.httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		return fmt.Errorf("failed to start API server: %w", err)
+	}
+
+	return nil
+}
+
+// Stop gracefully stops the API server
+func (s *Server) Stop(ctx context.Context) error {
+	log.Logger.Info("Shutting down API server")
+
+	return s.httpServer.Shutdown(ctx)
+}
+
+// healthHandler handles health check requests
+func healthHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprintf(w, `{"status": "ok", "timestamp": "%s"}`, time.Now().Format(time.RFC3339))
+}
+
+// rootHandler handles root path requests
+func rootHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprintf(w, "PubDataHub API Server\n")
+}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1,0 +1,61 @@
+package api_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/brainless/PubDataHub/internal/api"
+	"github.com/brainless/PubDataHub/internal/log"
+)
+
+func TestAPIServerStart(t *testing.T) {
+	// Initialize logger for tests
+	log.InitLogger(true)
+
+	// Test that the server starts and responds to requests
+	addr := ":8081" // Use a different port to avoid conflicts
+	server := api.NewServer(addr)
+
+	// Start server in a goroutine
+	go func() {
+		if err := server.Start(); err != nil {
+			t.Errorf("Failed to start server: %v", err)
+		}
+	}()
+
+	// Give the server a moment to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Test health endpoint
+	resp, err := http.Get(fmt.Sprintf("http://localhost%s/health", addr))
+	if err != nil {
+		t.Fatalf("Failed to make request to health endpoint: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", resp.StatusCode)
+	}
+
+	// Test root endpoint
+	resp, err = http.Get(fmt.Sprintf("http://localhost%s/", addr))
+	if err != nil {
+		t.Fatalf("Failed to make request to root endpoint: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", resp.StatusCode)
+	}
+
+	// Shutdown the server
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := server.Stop(ctx); err != nil {
+		t.Errorf("Failed to stop server: %v", err)
+	}
+}


### PR DESCRIPTION
This PR implements the basic structure for the web server and API endpoints as requested in issue #69. It includes: - Creation of a new `api` package in the `internal` directory - Implementation of a basic web server using the `net/http` package - Addition of a new `serve` command to start the web server - Integration tests for the API server - Health check and root endpoints